### PR TITLE
[Config] use Ndict to keep existing object configs in storage

### DIFF
--- a/octobot_tentacles_manager/api/__init__.py
+++ b/octobot_tentacles_manager/api/__init__.py
@@ -75,6 +75,7 @@ from octobot_tentacles_manager.api.loader import (
 )
 from octobot_tentacles_manager.api.inspector import (
     get_installed_tentacles_modules,
+    get_installed_tentacles_modules_dict,
     get_tentacle_group,
     get_tentacle_version,
     get_tentacle_origin_package,

--- a/octobot_tentacles_manager/api/configurator.py
+++ b/octobot_tentacles_manager/api/configurator.py
@@ -122,8 +122,8 @@ def get_activated_tentacles(tentacles_setup_config: configuration.TentaclesSetup
 
 
 def update_tentacle_config(tentacles_setup_config: configuration.TentaclesSetupConfiguration,
-                           tentacle_class: object, config_data: dict) -> None:
-    configuration.update_config(tentacles_setup_config, tentacle_class, config_data)
+                           tentacle_class: object, config_data: dict, keep_existing: bool=True) -> None:
+    configuration.update_config(tentacles_setup_config, tentacle_class, config_data, keep_existing)
 
 
 def import_user_tentacles_config_folder(tentacles_setup_config: configuration.TentaclesSetupConfiguration):

--- a/octobot_tentacles_manager/api/inspector.py
+++ b/octobot_tentacles_manager/api/inspector.py
@@ -20,10 +20,30 @@ import octobot_commons.tentacles_management as tentacles_management
 
 import octobot_tentacles_manager.constants as constants
 import octobot_tentacles_manager.loaders as loaders
+import octobot_tentacles_manager.enums as manager_enums
 
 
 def get_installed_tentacles_modules() -> set:
     return set(tentacle for tentacle in loaders.get_tentacle_classes().values())
+
+
+def get_installed_tentacles_modules_dict() -> dict:
+    return {_tentacle.name: {
+        manager_enums.InstalledTentaclesModule.NAME.value:_tentacle.name,
+        manager_enums.InstalledTentaclesModule.IN_DEV_MODE.value:_tentacle.in_dev_mode,
+        manager_enums.InstalledTentaclesModule.ARTIFACT_NAME.value:_tentacle.ARTIFACT_NAME,
+        manager_enums.InstalledTentaclesModule.METADATA.value:_tentacle.metadata,
+        manager_enums.InstalledTentaclesModule.ORIGIN_PACKAGE.value:_tentacle.origin_package,
+        manager_enums.InstalledTentaclesModule.ORIGIN_REPOSITORY.value:_tentacle.origin_repository,
+        manager_enums.InstalledTentaclesModule.TENTACLE_CLASS_NAMES.value:_tentacle.tentacle_class_names,
+        manager_enums.InstalledTentaclesModule.TENTACLE_GROUP.value:_tentacle.tentacle_group,
+        manager_enums.InstalledTentaclesModule.TENTACLE_MODULE_PATH.value:_tentacle.tentacle_module_path,
+        manager_enums.InstalledTentaclesModule.TENTACLE_PATH.value:_tentacle.tentacle_path,
+        manager_enums.InstalledTentaclesModule.TENTACLE_ROOT_PATH.value:_tentacle.tentacle_root_path,
+        manager_enums.InstalledTentaclesModule.TENTACLE_ROOT_TYPE.value:_tentacle.tentacle_root_type,
+        manager_enums.InstalledTentaclesModule.TENTACLES_REQUIREMENTS.value:_tentacle.tentacles_requirements,
+        manager_enums.InstalledTentaclesModule.VERSION.value:_tentacle.version
+    } for _tentacle in loaders.get_tentacle_classes().values()}
 
 
 def get_tentacle_group(klass) -> str:

--- a/octobot_tentacles_manager/configuration/tentacle_configuration.py
+++ b/octobot_tentacles_manager/configuration/tentacle_configuration.py
@@ -16,6 +16,7 @@
 import os
 import os.path as path
 import shutil
+import naapc as naapc
 
 import octobot_tentacles_manager.configuration as configuration
 import octobot_tentacles_manager.constants as constants
@@ -33,7 +34,11 @@ def update_config(tentacles_setup_config, klass, config_update) -> None:
     config_file = _get_config_file_path(tentacles_setup_config, klass)
     current_config = configuration.read_config(config_file)
     # only update values in config update not to erase values in root config (might not be editable)
+    
+    # use NDict to keep inactive settings in objects
+    current_config = naapc.NDict(current_config)
     current_config.update(config_update)
+    current_config = dict(current_config)
     config_file = _get_config_file_path(tentacles_setup_config, klass, updated_config=True)
     configuration.write_config(config_file, current_config)
 

--- a/octobot_tentacles_manager/configuration/tentacle_configuration.py
+++ b/octobot_tentacles_manager/configuration/tentacle_configuration.py
@@ -30,15 +30,17 @@ def get_config(tentacles_setup_config, klass) -> dict:
     return configuration.read_config(config_path)
 
 
-def update_config(tentacles_setup_config, klass, config_update) -> None:
+def update_config(tentacles_setup_config, klass, config_update, keep_existing = True) -> None:
     config_file = _get_config_file_path(tentacles_setup_config, klass)
     current_config = configuration.read_config(config_file)
     # only update values in config update not to erase values in root config (might not be editable)
-    
-    # use NDict to keep inactive settings in objects
-    current_config = naapc.NDict(current_config)
-    current_config.update(config_update)
-    current_config = dict(current_config)
+    if keep_existing:
+        # use NDict to keep inactive settings in objects
+        current_config = naapc.NDict(current_config)
+        current_config.update(config_update)
+        current_config = dict(current_config)
+    else:
+        current_config.update(config_update)
     config_file = _get_config_file_path(tentacles_setup_config, klass, updated_config=True)
     configuration.write_config(config_file, current_config)
 

--- a/octobot_tentacles_manager/enums.py
+++ b/octobot_tentacles_manager/enums.py
@@ -26,3 +26,19 @@ class ArtifactTypes(enum.Enum):
 class UploaderTypes(enum.Enum):
     S3 = "s3"
     NEXUS = "nexus"
+
+class InstalledTentaclesModule(enum.Enum):
+    NAME = "name"
+    IN_DEV_MODE = "in_dev_mode"
+    ARTIFACT_NAME = "artifact_name"
+    METADATA = "metadata"
+    ORIGIN_PACKAGE = "origin_package"
+    ORIGIN_REPOSITORY = "origin_repository"
+    TENTACLE_CLASS_NAMES = "tentacle_class_names"
+    TENTACLE_GROUP = "tentacle_group"
+    TENTACLE_MODULE_PATH = "tentacle_module_path"
+    TENTACLE_PATH = "tentacle_path"
+    TENTACLE_ROOT_PATH = "tentacle_root_path"
+    TENTACLE_ROOT_TYPE = "tentacle_root_type"
+    TENTACLES_REQUIREMENTS = "tentacles_requirements"
+    VERSION = "version"

--- a/octobot_tentacles_manager/util/hashing.py
+++ b/octobot_tentacles_manager/util/hashing.py
@@ -23,8 +23,14 @@ import octobot_tentacles_manager.configuration.tentacle_configuration as tentacl
 def get_tentacles_code_hash(tentacles: list) -> str:
     full_code = ""
     for linked_tentacle in tentacles:
-        code_location = linked_tentacle.get_script() if hasattr(linked_tentacle, "get_script") \
+        code_location = (
+            linked_tentacle.get_script()
+            if (
+                hasattr(linked_tentacle, "get_script")
+                and linked_tentacle.TRADING_SCRIPT_MODULE
+            )
             else linked_tentacle.__class__
+        )
         full_code = f"{full_code}{inspect.getsource(code_location)}"
     return hashlib.sha256(full_code.encode()).hexdigest()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ aiofiles>=0.6.0, <0.7
 aiohttp>=3.8.1
 
 # Templating requirements
-jinja2>=3.0.3
+jinja2>=3.1.2
 
 # artifact metadata
 pyyaml>=6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,6 @@ packaging==21.3
 
 # s3
 aioboto3==9.3.1
+
+# use NDict to keep inactive settings in objects
+naapc==1.5.0

--- a/tests/configuration/test_tentacle_configuration.py
+++ b/tests/configuration/test_tentacle_configuration.py
@@ -29,6 +29,7 @@ from octobot_tentacles_manager.configuration.tentacle_configuration import get_c
 import octobot_tentacles_manager.util as util
 import octobot_tentacles_manager.constants as constants
 from octobot_tentacles_manager.loaders.tentacle_loading import reload_tentacle_by_tentacle_class
+from tests.workers.octobot_version import get_installation_context_octobot_version
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
@@ -101,11 +102,10 @@ async def test_fill_tentacle_config():
 
     setup_config = configuration.TentaclesSetupConfiguration()
     setup_config.fill_tentacle_config(available_tentacle, constants.TENTACLE_CONFIG_FILE_NAME)
-    assert setup_config.installation_context == {
-        constants.TENTACLE_INSTALLATION_CONTEXT_OCTOBOT_VERSION:
-            constants.TENTACLE_INSTALLATION_CONTEXT_OCTOBOT_VERSION_UNKNOWN
-    }
+    assert setup_config.installation_context == get_installation_context_octobot_version() 
 
+    setup_config.installation_context[constants.TENTACLE_INSTALLATION_CONTEXT_OCTOBOT_VERSION] \
+        = constants.TENTACLE_INSTALLATION_CONTEXT_OCTOBOT_VERSION_UNKNOWN
     assert not api.are_tentacles_up_to_date(setup_config,
                                             constants.TENTACLE_INSTALLATION_CONTEXT_OCTOBOT_VERSION_UNKNOWN)
     assert not api.are_tentacles_up_to_date(setup_config, '1.0.0')

--- a/tests/workers/octobot_version.py
+++ b/tests/workers/octobot_version.py
@@ -1,0 +1,12 @@
+import octobot_tentacles_manager.configuration as configuration
+import octobot_tentacles_manager.constants as constants
+import octobot_tentacles_manager.util as util
+
+
+def get_installation_context_octobot_version() -> dict:
+    setup_config = configuration.TentaclesSetupConfiguration()
+    available_tentacle = util.load_tentacle_with_metadata(constants.TENTACLES_PATH)
+    setup_config.fill_tentacle_config(
+        available_tentacle, constants.TENTACLE_CONFIG_FILE_NAME
+    )
+    return setup_config.installation_context

--- a/tests/workers/test_install_worker.py
+++ b/tests/workers/test_install_worker.py
@@ -28,6 +28,7 @@ from octobot_tentacles_manager.workers.install_worker import InstallWorker
 from octobot_tentacles_manager.models.tentacle import Tentacle
 from octobot_tentacles_manager.util.tentacle_fetching import fetch_and_extract_tentacles
 from tests import event_loop, clean, fake_profiles, TEMP_DIR, OTHER_PROFILE
+from tests.workers.octobot_version import get_installation_context_octobot_version
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
@@ -56,9 +57,7 @@ async def test_install_two_tentacles(clean):
     with open(USER_REFERENCE_TENTACLE_CONFIG_FILE_PATH, "r") as config_f:
         ref_profile_config = json.load(config_f)
         assert ref_profile_config == {
-            'installation_context': {
-                'octobot_version': 'unknown'
-            },
+            'installation_context': get_installation_context_octobot_version(),
             'registered_tentacles': {
                 'OctoBot-Default-Tentacles': tentacles_path
             },
@@ -95,9 +94,7 @@ async def test_install_one_tentacle_with_requirement(clean):
     # test tentacles config
     with open(USER_REFERENCE_TENTACLE_CONFIG_FILE_PATH, "r") as config_f:
         assert json.load(config_f) == {
-            'installation_context': {
-                'octobot_version': 'unknown'
-            },
+            'installation_context': get_installation_context_octobot_version(),
             'registered_tentacles': {
                 'OctoBot-Default-Tentacles': UNKNOWN_TENTACLES_PACKAGE_LOCATION
             },
@@ -132,9 +129,7 @@ async def test_install_all_tentacles(clean):
     # test tentacles config
     with open(USER_REFERENCE_TENTACLE_CONFIG_FILE_PATH, "r") as config_f:
         assert json.load(config_f) == {
-            'installation_context': {
-                'octobot_version': 'unknown'
-            },
+            'installation_context': get_installation_context_octobot_version(),
             'registered_tentacles': {
                 'OctoBot-Default-Tentacles': tentacles_path
             },

--- a/tests/workers/test_uninstall_worker.py
+++ b/tests/workers/test_uninstall_worker.py
@@ -24,7 +24,7 @@ from octobot_tentacles_manager.constants import TENTACLES_PATH, \
     USER_REFERENCE_TENTACLE_CONFIG_FILE_PATH, DEFAULT_BOT_PATH, TENTACLE_CONFIG, TENTACLES_EVALUATOR_PATH, \
     TENTACLES_EVALUATOR_REALTIME_PATH
 from octobot_tentacles_manager.workers.install_worker import InstallWorker
-
+from tests.workers.octobot_version import get_installation_context_octobot_version
 from octobot_tentacles_manager.models.tentacle import Tentacle
 from octobot_tentacles_manager.workers.uninstall_worker import UninstallWorker
 from octobot_tentacles_manager.util.tentacle_fetching import fetch_and_extract_tentacles
@@ -55,9 +55,7 @@ async def test_uninstall_two_tentacles(clean):
     assert tentacles_files_count < 67
     with open(USER_REFERENCE_TENTACLE_CONFIG_FILE_PATH, "r") as config_f:
         assert json.load(config_f) == {
-            'installation_context': {
-                'octobot_version': 'unknown'
-            },
+            'installation_context': get_installation_context_octobot_version(),
             'registered_tentacles': {
                 'OctoBot-Default-Tentacles': tentacles_path
             },
@@ -144,9 +142,7 @@ async def test_uninstall_all_tentacles(clean):
     assert tentacles_files_count == CLEAN_TENTACLES_ARCHITECTURE_FILES_FOLDERS_COUNT
     with open(USER_REFERENCE_TENTACLE_CONFIG_FILE_PATH, "r") as config_f:
         assert json.load(config_f) == {
-            'installation_context': {
-                'octobot_version': 'unknown'
-            },
+            'installation_context': get_installation_context_octobot_version(),
             'registered_tentacles': {},
             'tentacle_activation': {
                 'Backtesting': {},

--- a/tests/workers/test_update_worker.py
+++ b/tests/workers/test_update_worker.py
@@ -20,7 +20,6 @@ from shutil import rmtree
 import os
 from os import walk, path
 
-import octobot_commons.constants as commons_constants
 from octobot_commons.logging.logging_util import set_logging_level
 from octobot_tentacles_manager.constants import USER_REFERENCE_TENTACLE_SPECIFIC_CONFIG_PATH, \
     USER_REFERENCE_TENTACLE_CONFIG_FILE_PATH, TENTACLES_PATH, DEFAULT_BOT_PATH, UNKNOWN_TENTACLES_PACKAGE_LOCATION, \
@@ -31,6 +30,7 @@ from octobot_tentacles_manager.workers.update_worker import UpdateWorker
 from octobot_tentacles_manager.models.tentacle import Tentacle
 from octobot_tentacles_manager.util.tentacle_fetching import fetch_and_extract_tentacles
 from tests import event_loop, clean, TEMP_DIR, OTHER_PROFILE
+from tests.workers.octobot_version import get_installation_context_octobot_version
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
@@ -65,9 +65,7 @@ async def test_update_two_tentacles(clean):
     # test tentacles config
     with open(USER_REFERENCE_TENTACLE_CONFIG_FILE_PATH, "r") as config_f:
         assert json.load(config_f) == {
-            'installation_context': {
-                'octobot_version': 'unknown'
-            },
+            'installation_context': get_installation_context_octobot_version(),
             'registered_tentacles': {
                 'OctoBot-Default-Tentacles': UNKNOWN_TENTACLES_PACKAGE_LOCATION
             },


### PR DESCRIPTION
- when nested object configs are used, previously a change in the object settings structure did overwrite existing unused configs. With ndict, we'll keep old unused nested configs, in case the user switches back to the previous object settings tree, to still have all the settings filled out as before.
- add keep_existing config option to define which way to use